### PR TITLE
Set up Cursor Cloud dev environment + AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a single Next.js 16 (App Router, React 19, Turbopack) marketing site called **Belongings**. Package manager is **npm** (`package-lock.json`). There is no database or backend infrastructure — API routes run inside the Next.js process.
+
+### Services
+- **Next.js dev server** — the only process. Start with `npm run dev` (serves on `http://localhost:3000`). This hosts both the pages and the API routes (`/api/submit-story`, `/api/uploadthing`).
+
+### Lint / build / test
+- Lint: `npm run lint` (ESLint 9; the repo currently reports only `@next/next/no-img-element` warnings, 0 errors).
+- Build: `npm run build`.
+- There is no automated test suite.
+
+### Story submission (core interactive feature) — external dependency
+- The "Submit Your Story" form posts to `/api/submit-story`, which uploads images to **UploadThing** (a hosted SaaS) via `UTApi`.
+- This step requires the `UPLOADTHING_TOKEN` environment variable. Without it, the API validates fields correctly (returns 400 for missing fields/images) but the image upload step fails with `"Image upload failed. Ensure UPLOADTHING_TOKEN is set."` (500). This is expected when the token is absent — it is not a code bug.
+- To exercise the full submission flow end-to-end, set `UPLOADTHING_TOKEN` (add it as a secret).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Sets up the development environment for the **Belongings** Next.js site and documents it for future cloud agents.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering the single Next.js service, lint/build commands, and the `UPLOADTHING_TOKEN` requirement for the story-submission upload flow.
- Update script for future runs is `npm install` (configured via the environment setup, not committed).

No application code was changed.

## Environment verified
- `npm install` — dependencies installed (Node 22, npm 10).
- `npm run lint` — passes (only `@next/next/no-img-element` warnings, 0 errors).
- `npm run build` — production build succeeds.
- `npm run dev` — dev server runs on `http://localhost:3000` (homepage returns 200).

## Hello-world walkthrough
Filled out and submitted the core "Submit Your Story" form. The form, image preview, and `/api/submit-story` route run end-to-end; the final image upload returns `Failed to upload one or more images.` only because no `UPLOADTHING_TOKEN` (external SaaS secret) is set — expected, not a code bug. API validation confirmed via curl (400 for missing fields/images, upload step reached otherwise).

[belongings_submit_story_demo.mp4](https://cursor.com/agents/bc-dc956f35-70b0-4b32-a0de-29d6b853933e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbelongings_submit_story_demo.mp4)

[Home hero](https://cursor.com/agents/bc-dc956f35-70b0-4b32-a0de-29d6b853933e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhome_hero.webp)
[Form filled with image preview](https://cursor.com/agents/bc-dc956f35-70b0-4b32-a0de-29d6b853933e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fform_filled_with_preview.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc956f35-70b0-4b32-a0de-29d6b853933e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc956f35-70b0-4b32-a0de-29d6b853933e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

