### PR TITLE
Add Supabase story submission persistence

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "belongings",
       "version": "0.1.0",
       "dependencies": {
+        "@supabase/supabase-js": "^2.108.2",
         "@uploadthing/react": "^7.3.3",
         "next": "16.1.7",
         "react": "19.2.3",
@@ -1343,6 +1344,90 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
+    },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.108.2",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.108.2.tgz",
+      "integrity": "sha512-tNaQmBgodDZwgB40mRwVbxFy8IDYwjdpcZ0BYrWiwlULCSQoJj4QoG4zgJT7QRPXcqipefNOzvO/qAu4dF98ag==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.108.2",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.108.2.tgz",
+      "integrity": "sha512-RNUX8EiBy3iLwAX19jtRzLyePnl11/fHcgwDHLnpKcDSXt/5qBnh3LUwAtIjT21Q66QsmNUR2esrHziLCpNubw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.2.tgz",
+      "integrity": "sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.108.2",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.108.2.tgz",
+      "integrity": "sha512-GQ28/Y8hk3CFmkb3kXH1h/AQx6JIYSQfO0CJMRVBcEKZoNy6C45cXAZ4fcJvRC5Id0cs6xnkUV0+c0rIocigsw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.108.2",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.108.2.tgz",
+      "integrity": "sha512-aAGxCSUemZvQIibnCdvNvgaKib28I4rfrNjKbQ9cG1uBLwUsI7hVpGXgEbypCCDhLjQlDTAiJlu7rgljYUT73g==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "^0.4.2",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.108.2",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.108.2.tgz",
+      "integrity": "sha512-TVZPQxXGxY2+A6yTtm77zUHsh70lBhYUEaJL8RQC+BghcX/ygiMG/rmXrNVBce30/WAeNPa8FiG8HbqlGeV05g==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.108.2",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.108.2.tgz",
+      "integrity": "sha512-hFhnPveb5JQg4a0QYicM0swT253YHMdfeRAl2BKHOlI5VAzuHxUGSr8RbwNLYNPauWOgQMS1H8sz8bvYlgwUfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.108.2",
+        "@supabase/functions-js": "2.108.2",
+        "@supabase/postgrest-js": "2.108.2",
+        "@supabase/realtime-js": "2.108.2",
+        "@supabase/storage-js": "2.108.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
@@ -4132,6 +4217,15 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/ignore": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.108.2",
     "@uploadthing/react": "^7.3.3",
     "next": "16.1.7",
     "react": "19.2.3",

--- a/src/app/api/submit-story/route.ts
+++ b/src/app/api/submit-story/route.ts
@@ -85,7 +85,7 @@ export async function POST(request: NextRequest) {
   if (insertError) {
     console.error('[submit-story] Supabase insert failed:', insertError);
     return NextResponse.json(
-      { error: 'Images uploaded successfully, but saving the story submission failed.' },
+      { error: 'Your file uploaded, but your story was not saved. Please try again.' },
       { status: 500 },
     );
   }

--- a/src/app/api/submit-story/route.ts
+++ b/src/app/api/submit-story/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { UTApi } from 'uploadthing/server';
+import { supabase } from '@/lib/supabaseClient';
 
 export async function POST(request: NextRequest) {
   let formData: FormData;
@@ -12,6 +13,7 @@ export async function POST(request: NextRequest) {
 
   const fullName = formData.get('fullName') as string | null;
   const email = formData.get('email') as string | null;
+  const phone = formData.get('phone') as string | null;
   const objectName = formData.get('objectName') as string | null;
   const description = formData.get('description') as string | null;
   const imageFiles = formData.getAll('images').filter((f): f is File => f instanceof File);
@@ -60,9 +62,33 @@ export async function POST(request: NextRequest) {
       { status: 500 },
     );
   }
-  const imageUrls = resultsArray.filter((r) => r.data).map((r) => r.data!.ufsUrl);
+  const uploadedFiles = resultsArray
+    .filter((r): r is typeof r & { data: NonNullable<typeof r.data> } => r.data !== null)
+    .map((r) => ({
+      url: r.data.ufsUrl,
+      key: r.data.key,
+      name: r.data.name,
+      size: r.data.size,
+      type: r.data.type,
+    }));
+  const imageUrls = uploadedFiles.map((file) => file.url);
 
-  // TODO: Send submission fields (fullName, email, phone: formData.get('phone'), objectName, description, imageUrls) to an email
+  const { error: insertError } = await supabase.from('submissions').insert({
+    full_name: fullName,
+    email,
+    phone: phone || null,
+    object_name: objectName,
+    description,
+    image_urls: imageUrls,
+  });
+
+  if (insertError) {
+    console.error('[submit-story] Supabase insert failed:', insertError);
+    return NextResponse.json(
+      { error: 'Images uploaded successfully, but saving the story submission failed.' },
+      { status: 500 },
+    );
+  }
 
   return NextResponse.json({ success: true, imageUrls });
 }

--- a/src/components/home/SubmitStory.tsx
+++ b/src/components/home/SubmitStory.tsx
@@ -31,6 +31,7 @@ export default function SubmitStory() {
   });
   const [images, setImages] = useState<ImageEntry[]>([]);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const submittingRef = useRef(false);
   // Tracks all created URLs so we can revoke them on unmount.
   const createdUrlsRef = useRef<Set<string>>(new Set());
 
@@ -76,6 +77,9 @@ export default function SubmitStory() {
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    if (submittingRef.current) return;
+
+    submittingRef.current = true;
     setSubmitError(null);
     setSubmitting(true);
 
@@ -112,6 +116,7 @@ export default function SubmitStory() {
     } catch {
       setSubmitError('An unexpected error occurred. Please try again.');
     } finally {
+      submittingRef.current = false;
       setSubmitting(false);
     }
   };

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,0 +1,14 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabasePublishableKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
+
+if (!supabaseUrl) {
+  throw new Error('Missing NEXT_PUBLIC_SUPABASE_URL environment variable.');
+}
+
+if (!supabasePublishableKey) {
+  throw new Error('Missing NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY environment variable.');
+}
+
+export const supabase = createClient(supabaseUrl, supabasePublishableKey);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add `@supabase/supabase-js` and reusable `src/lib/supabaseClient.ts`
- Save one `submissions` row only after `UTApi.uploadFiles(...)` succeeds
- Preserve the existing UploadThing upload path and return distinct upload vs database failure messages
- Map confirmed `submissions` columns: `full_name`, `email`, `phone`, `object_name`, `description`, `image_urls`
- Harden the form against duplicate double-click submissions with an immediate in-flight guard while keeping the existing disabled button state

## Testing
- `npm run lint` (passes with existing `@next/next/no-img-element` warnings)
- `npm run build`
- Posted a generated PNG to `/api/submit-story` after enabling the Supabase public insert policy; endpoint returned `200` with an UploadThing URL and no Supabase insert error
- Browser double-click verification against the real form: rapid double-clicking `Submit Your Story` sent exactly one `POST /api/submit-story` and returned `200`
- A publishable-key readback query for a unique test email returned zero rows, which is consistent with no public SELECT policy; the app insert path itself succeeded because the route only returns 200 after `supabase.from('submissions').insert(...)` reports no error
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1497e888-0357-46c6-a7d0-8d6afd4f97b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1497e888-0357-46c6-a7d0-8d6afd4f97b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

